### PR TITLE
Refactor all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ import (
   "io/ioutil"
 
   "github.com/Iwark/spreadsheet"
-  "golang.org/x/oauth2"
+  "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 )
 
 func main(){
   data, _ := ioutil.ReadFile("client_secret.json")
   conf, _ := google.JWTConfigFromJSON(data, spreadsheet.SpreadsheetScope)
-  client := conf.Client(oauth2.NoContext)
+  client := conf.Client(context.TODO())
 
-  service, _ := spreadsheet.New(client)
-  sheets, _ := service.Sheets.Worksheets("1mYiA2T4_QTFUkAXk0BE3u7snN2o5FgSRqxmRrn_Dzh4")
+  service := &spreadsheet.Service{Client:(client)}
+  sheets, _ := service.Get("1mYiA2T4_QTFUkAXk0BE3u7snN2o5FgSRqxmRrn_Dzh4")
   ws, _ = sheets.Get(0)
   for _, row := range ws.Rows {
     for _, cell := range row {


### PR DESCRIPTION
This commit messes with everything.  Still needs more testing, but the
API changes make more sense to me.

- Delete SheetsService.  Useless abstraction.
- Remove New in favor of composite literals.
- Rename Worksheets type to Spreadsheet.
- Rename GSCell type to gsCell.
- Rename Service.Worksheets() to Get.
- Rename Spreadsheet.Entries to Worksheets.
- Rename Spreadsheet.AddWorksheet to NewWorksheet.
- Move MaxSync and MaxConns into Service struct.
- Add Visibility support.
- Add Return Empty support.
- Add godoc comments.
- Use ID instead of Id.
- Use fmt.Errorf instead of errors.New + fmt.Sprintf
- Use context.TODO() instead of oath2.NoContext in examples.