### PR TITLE
Fix numberToLetter func

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,25 +1,9 @@
 package spreadsheet
 
-var letters = [...]string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
-	"N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"}
+func numberToLetter(num int) string {
+	if num <= 0 {
+		return ""
+	}
 
-func numberToLetter(num int) (str string) {
-	if num == 0 {
-		return
-	}
-	nums := []int{}
-	for {
-		nums = append(nums, num%26)
-		num = num / 26
-		if num == 0 {
-			break
-		}
-	}
-	for i, j := 0, len(nums)-1; i < j; i, j = i+1, j-1 {
-		nums[i], nums[j] = nums[j], nums[i]
-	}
-	for _, n := range nums {
-		str += letters[n-1]
-	}
-	return
+	return numberToLetter(int((num-1)/26)) + string(byte(65+(num-1)%26))
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -9,6 +9,17 @@ import (
 func TestNumberToLetter(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal("C", numberToLetter(3))
+	assert.Equal("Z", numberToLetter(26))
 	assert.Equal("AB", numberToLetter(28))
+	assert.Equal("AZ", numberToLetter(52))
 	assert.Equal("AAC", numberToLetter(705))
+	assert.Equal("YZ", numberToLetter(676))
+	assert.Equal("ZA", numberToLetter(677))
+}
+
+func BenchmarkNumberToLetter(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = numberToLetter(i)
+	}
 }


### PR DESCRIPTION
Make a faster, panic-free numberToLetter.

BenchmarkNumberToLetter-2     5000000   264 ns/op    6 B/op   3 allocs/op
BenchmarkNumberToLetterOld-2  5000000   383 ns/op   64 B/op   5 allocs/op

Fixes #11