### PR TITLE
Fix TabColor bug

### DIFF
--- a/sheet_properties.go
+++ b/sheet_properties.go
@@ -8,6 +8,6 @@ type SheetProperties struct {
 	SheetType      string         `json:"sheetType"`
 	GridProperties GridProperties `json:"gridProperties"`
 	Hidden         bool           `json:"hidden"`
-	TabColor       string         `json:"tabColor"`
+	TabColor       TabColor       `json:"tabColor"`
 	RightToLeft    bool           `json:"rightToLeft"`
 }

--- a/tab_color.go
+++ b/tab_color.go
@@ -1,0 +1,9 @@
+package spreadsheet
+
+// TabColor is color of a tab.
+type TabColor struct {
+	Red   float32 `json:"red"`
+	Green float32 `json:"green"`
+	Blue  float32 `json:"blue"`
+	Alpha float32 `json:"alpha"`
+}


### PR DESCRIPTION
`SheetProperties.TabColor` is not a string but an object, according to
[spreadsheet spec](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#SheetProperties).

Calling FetchSpreadsheet triggers `json: cannot unmarshal object into Go
struct field SheetProperties.tabColor of type string` if the spreadsheet
has tab-color set.