### PR TITLE
Consider making utils functions public and potentially add a couple

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -11,5 +11,5 @@ type Cell struct {
 
 // Pos returns the cell's position like "A1"
 func (cell *Cell) Pos() string {
-	return numberToLetter(int(cell.Column)+1) + fmt.Sprintf("%d", cell.Row+1)
+	return NumberToLetter(int(cell.Column)+1) + fmt.Sprintf("%d", cell.Row+1)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,62 @@
 package spreadsheet
 
-func numberToLetter(num int) string {
+import (
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+func NumberToLetter(num int) string {
 	if num <= 0 {
 		return ""
 	}
 
-	return numberToLetter(int((num-1)/26)) + string(byte(65+(num-1)%26))
+	return NumberToLetter(int((num-1)/26)) + string(byte(65+(num-1)%26))
+}
+
+func LetterToNumber(letter string) (int, error) {
+	var total int
+	l := len(letter)
+	if l >= 14 {
+		return 0, errors.New("only references shorter than 14 characters are supported")
+	}
+	for n, c := range []byte(letter) {
+		v := int(byte(c) - 65)
+		// On invalid value, just return zero.
+		if (v < 0) || (v > 25) {
+			return 0, errors.New("expecting upper case A-Z only")
+		}
+		// Calculate 26 to the power of the place value.
+		r := 1
+		for i := 1; i < l-n; i++ {
+			r *= 26
+		}
+		// Multiply by the character value starting from A=1 and add to total.
+		total += r * ((v % 26) + 1)
+	}
+	return total, nil
+}
+
+func ParseReferenceRange(ref string) (sheet string, x1, y1, x2, y2 int, err error) {
+	re := regexp.MustCompile("^'?([^!]+?)'?[!]([A-Z]+)([0-9]+):([A-Z]+)([0-9]+)$")
+	xyparts := re.FindAllStringSubmatch(ref, -1)
+	if xyparts == nil {
+		err = errors.New("can't parse sheet reference")
+		return
+	}
+	sheet = xyparts[0][1]
+	x1, err = LetterToNumber(xyparts[0][2])
+	if err != nil {
+		return
+	}
+	y1, err = strconv.Atoi(xyparts[0][3])
+	if err != nil {
+		return
+	}
+	x2, err = LetterToNumber(xyparts[0][4])
+	if err != nil {
+		return
+	}
+	y2, err = strconv.Atoi(xyparts[0][5])
+	return
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestNumberToLetter(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal("C", numberToLetter(3))
-	assert.Equal("Z", numberToLetter(26))
-	assert.Equal("AB", numberToLetter(28))
-	assert.Equal("AZ", numberToLetter(52))
-	assert.Equal("AAC", numberToLetter(705))
-	assert.Equal("YZ", numberToLetter(676))
-	assert.Equal("ZA", numberToLetter(677))
+	assert.Equal("C", NumberToLetter(3))
+	assert.Equal("Z", NumberToLetter(26))
+	assert.Equal("AB", NumberToLetter(28))
+	assert.Equal("AZ", NumberToLetter(52))
+	assert.Equal("AAC", NumberToLetter(705))
+	assert.Equal("YZ", NumberToLetter(676))
+	assert.Equal("ZA", NumberToLetter(677))
 }
 
 func BenchmarkNumberToLetter(b *testing.B) {


### PR DESCRIPTION
I happened to write a couple of utility functions during a project and was wondering if one or both would be useful to others.

The first is the exact opposite of numberToLetter().
The second parses "sheet?A1:Z5" type references into values than can be looped over to retrieve a subset of the sheet - this is not very generalized (it doesn't handle non-range references, for instance) but was sufficiently useful in my case, which was allowing a configurable input range in a recognizable format.
This PR also renames numberToLetter to NumberToLetter so it is exported and also a utility function (since it was also generally useful).

If there is interest I would be happy to take a pass at function docs and tests. I did a bit of testing for letterToNumber making sure it worked for even large letter combinations (ZZZZ etc), but was working in a separate project and so they would need adapting.