### PR TITLE
Support optional sheet creation at spreadsheet creation time

### DIFF
--- a/service.go
+++ b/service.go
@@ -56,10 +56,16 @@ type Service struct {
 
 // CreateSpreadsheet creates a spreadsheet with the given title
 func (s *Service) CreateSpreadsheet(spreadsheet Spreadsheet) (resp Spreadsheet, err error) {
+	sheets := make([]map[string]interface{}, 1)
+	for s := range spreadsheet.Sheets {
+		sheet := spreadsheet.Sheets[s]
+		sheets = append(sheets, map[string]interface{}{"properties": map[string]interface{}{"title": sheet.Properties.Title}})
+	}
 	body, err := s.post("/spreadsheets", map[string]interface{}{
 		"properties": map[string]interface{}{
 			"title": spreadsheet.Properties.Title,
 		},
+		"sheets": sheets,
 	})
 	if err != nil {
 		return

--- a/service_test.go
+++ b/service_test.go
@@ -33,6 +33,36 @@ func (suite *TestSuite) TestCreateSpreadsheet() {
 	suite.service.ExpandSheet(sheet, 20, 10)
 }
 
+func (suite *TestSuite) TestCreateSpreadsheetWithSheets() {
+	title := "testspreadsheet"
+	sheetTitles := []string{"sheet 1", "sheet 2"}
+	spreadsheet, err := suite.service.CreateSpreadsheet(Spreadsheet{
+		Properties: Properties{
+			Title: title,
+		},
+		Sheets: []Sheet{
+			Sheet{
+				Properties: SheetProperties{
+					Title: sheetTitles[0],
+				},
+			},
+			Sheet{
+				Properties: SheetProperties{
+					Title: sheetTitles[1],
+				},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Equal(spreadsheet.Properties.Title, title)
+	suite.Equal(spreadsheet.Sheets[0].Properties.Title, sheetTitles[0])
+	suite.Equal(spreadsheet.Sheets[1].Properties.Title, sheetTitles[1])
+	_, err = spreadsheet.SheetByIndex(0)
+	suite.Require().NoError(err)
+	_, err = spreadsheet.SheetByIndex(1)
+	suite.Require().NoError(err)
+}
+
 func (suite *TestSuite) TestFetchSpreadsheet() {
 	spreadsheet, err := suite.service.FetchSpreadsheet(spreadsheetID)
 	suite.Require().NoError(err)


### PR DESCRIPTION
Adds ability to create spreadsheets with multiple named sheets in them, and test to cover.

ex: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/create?apix_params=%7B%22resource%22%3A%7B%22properties%22%3A%7B%22title%22%3A%22fooby%22%7D%2C%22sheets%22%3A%5B%7B%22properties%22%3A%7B%22title%22%3A%22test%201%22%7D%7D%2C%7B%22properties%22%3A%7B%22title%22%3A%22test%202%22%7D%7D%5D%7D%7D