### PR TITLE
Add function to add/delete a sheet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: go
 go:
-- 1.5
-- 1.6
-- 1.7
-- 1.8
-- tip
+- "1.9"
+- "1.10"
+- "1.11"
+- "master"
 matrix:
   allow_failures:
-  - go: tip
+  - go: "master"
 before_install:
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover

--- a/service.go
+++ b/service.go
@@ -88,6 +88,45 @@ func (s *Service) FetchSpreadsheet(id string) (spreadsheet Spreadsheet, err erro
 	return
 }
 
+// ReloadSpreadsheet reloads the spreadsheet
+func (s *Service) ReloadSpreadsheet(spreadsheet *Spreadsheet) (err error) {
+	newSpreadsheet, err := s.FetchSpreadsheet(spreadsheet.ID)
+	if err != nil {
+		return
+	}
+	spreadsheet.Properties = newSpreadsheet.Properties
+	spreadsheet.Sheets = newSpreadsheet.Sheets
+	return
+}
+
+// AddSheet adds a sheet
+func (s *Service) AddSheet(spreadsheet *Spreadsheet, sheetProperties SheetProperties) (err error) {
+	r, err := newUpdateRequest(spreadsheet)
+	if err != nil {
+		return
+	}
+	err = r.AddSheet(sheetProperties).Do()
+	if err != nil {
+		return
+	}
+	err = s.ReloadSpreadsheet(spreadsheet)
+	return
+}
+
+// DeleteSheet deletes the sheet
+func (s *Service) DeleteSheet(spreadsheet *Spreadsheet, sheetID uint) (err error) {
+	r, err := newUpdateRequest(spreadsheet)
+	if err != nil {
+		return
+	}
+	err = r.DeleteSheet(sheetID).Do()
+	if err != nil {
+		return
+	}
+	err = s.ReloadSpreadsheet(spreadsheet)
+	return
+}
+
 // SyncSheet updates sheet
 func (s *Service) SyncSheet(sheet *Sheet) (err error) {
 	if sheet.newMaxRow > sheet.Properties.GridProperties.RowCount ||

--- a/service_test.go
+++ b/service_test.go
@@ -58,6 +58,22 @@ func (suite *TestSuite) TestFetchSpreadsheet() {
 	}
 }
 
+func (suite *TestSuite) TestAdd_DeleteSheet() {
+	spreadsheet, err := suite.service.FetchSpreadsheet(spreadsheetID)
+	suite.Require().NoError(err)
+	err = suite.service.AddSheet(&spreadsheet, SheetProperties{
+		Title: "TestAddedSheet",
+		Index: 1,
+	})
+	suite.Require().NoError(err)
+
+	sheet, err := spreadsheet.SheetByTitle("TestAddedSheet")
+	suite.Require().NoError(err)
+
+	err = suite.service.DeleteSheet(&spreadsheet, sheet.Properties.ID)
+	suite.Require().NoError(err)
+}
+
 func (suite *TestSuite) TestSyncSheet() {
 	spreadsheet, err := suite.service.FetchSpreadsheet(spreadsheetID)
 	suite.Require().NoError(err)

--- a/sheet_properties.go
+++ b/sheet_properties.go
@@ -2,12 +2,12 @@ package spreadsheet
 
 // SheetProperties is properties of a sheet.
 type SheetProperties struct {
-	ID             uint           `json:"sheetId"`
-	Title          string         `json:"title"`
-	Index          uint           `json:"index"`
-	SheetType      string         `json:"sheetType"`
-	GridProperties GridProperties `json:"gridProperties"`
-	Hidden         bool           `json:"hidden"`
-	TabColor       TabColor       `json:"tabColor"`
-	RightToLeft    bool           `json:"rightToLeft"`
+	ID             uint           `json:"sheetId,omitempty"`
+	Title          string         `json:"title,omitempty"`
+	Index          uint           `json:"index,omitempty"`
+	SheetType      string         `json:"sheetType,omitempty"`
+	GridProperties GridProperties `json:"gridProperties,omitempty"`
+	Hidden         bool           `json:"hidden,omitempty"`
+	TabColor       TabColor       `json:"tabColor,omitempty"`
+	RightToLeft    bool           `json:"rightToLeft,omitempty"`
 }

--- a/update_request.go
+++ b/update_request.go
@@ -127,12 +127,22 @@ func (r *updateRequest) DeleteNamedRange() {
 
 }
 
-func (r *updateRequest) AddSheet() {
-
+func (r *updateRequest) AddSheet(sheetProperties SheetProperties) *updateRequest {
+	r.body["requests"] = append(r.body["requests"], map[string]interface{}{
+		"addSheet": map[string]interface{}{
+			"properties": sheetProperties,
+		},
+	})
+	return r
 }
 
-func (r *updateRequest) DeleteSheet() {
-
+func (r *updateRequest) DeleteSheet(sheetID uint) *updateRequest {
+	r.body["requests"] = append(r.body["requests"], map[string]interface{}{
+		"deleteSheet": map[string]interface{}{
+			"sheetId": sheetID,
+		},
+	})
+	return r
 }
 
 func (r *updateRequest) AutoFill() {


### PR DESCRIPTION
This PR adds function to add / delete a sheet from a spreadsheet as below:

```
service := spreadsheet.NewServiceWithClient(client)
ss, err := service.FetchSpreadsheet(spreadsheetID)

err = service.AddSheet(&ss, spreadsheet.SheetProperties{
  Title: "TestAddedSheet",
  Index: 1,
})

sheet, err := ss.SheetByTitle("TestAddedSheet")

err = service.DeleteSheet(&ss, sheet.Properties.ID)
```