### PR TITLE
Faster cell update

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -79,15 +79,12 @@ func (sheet *Sheet) Update(row, column int, val string) {
 
 	if uint(len(sheet.Rows)) < sheet.newMaxRow+1 ||
 		uint(len(sheet.Columns)) < sheet.newMaxColumn+1 {
-		newRows, newColumns := newCells(sheet.newMaxRow, sheet.newMaxColumn)
-		for i := range sheet.Rows {
-			copy(newRows[i], sheet.Rows[i])
-		}
-		for i := range sheet.Columns {
-			copy(newColumns[i], sheet.Columns[i])
-		}
-		sheet.Rows = newRows
-		sheet.Columns = newColumns
+		sheet.Rows = appendCells(sheet.Rows, sheet.newMaxRow, sheet.newMaxColumn, func(i, t uint) Cell {
+			return Cell{Row: i, Column: t}
+		})
+		sheet.Columns = appendCells(sheet.Columns, sheet.newMaxColumn, sheet.newMaxRow, func(i, t uint) Cell {
+			return Cell{Row: t, Column: i}
+		})
 	}
 
 	cell := Cell{
@@ -141,4 +138,21 @@ func newCells(maxRow, maxColumn uint) (rows, columns [][]Cell) {
 		}
 	}
 	return
+}
+
+func appendCells(cells [][]Cell, maxRow, maxColumn uint, cell func(uint, uint) Cell) [][]Cell {
+	for i := uint(0); i < maxRow; i++ {
+		if len(cells) == 0 || int(i) > len(cells)-1 {
+			row := make([]Cell, 0, maxColumn)
+			for t := uint(0); t < maxColumn; t++ {
+				row = append(row, cell(i, t))
+			}
+			cells = append(cells, row)
+		} else {
+			for t := uint(len(cells[i]) - 1); t < maxColumn; t++ {
+				cells[i] = append(cells[i], cell(i, t))
+			}
+		}
+	}
+	return cells
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -21,3 +21,18 @@ func TestNewCells(t *testing.T) {
 	assert.Equal(uint(0), columns[2][0].Row)
 	assert.Equal(uint(2), columns[2][2].Column)
 }
+
+func benchmarkUpdate(t int, b *testing.B) {
+	for f := 0; f < b.N; f++ {
+		s := Sheet{}
+		b.ReportAllocs()
+		for i := 0; i < t; i++ {
+			s.Update(i, i, "")
+		}
+	}
+}
+
+func BenchmarkUpdate1(b *testing.B)    { benchmarkUpdate(1, b) }
+func BenchmarkUpdate10(b *testing.B)   { benchmarkUpdate(10, b) }
+func BenchmarkUpdate100(b *testing.B)  { benchmarkUpdate(100, b) }
+func BenchmarkUpdate1000(b *testing.B) { benchmarkUpdate(1000, b) }


### PR DESCRIPTION
Closes #41 
Update appends cells as needed now instead of using newCells() and copy()

Old:
```
BenchmarkUpdate1-4      	 3000000	       436 ns/op	     392 B/op	       8 allocs/op
BenchmarkUpdate10-4     	  100000	     18974 ns/op	   36120 B/op	     165 allocs/op
BenchmarkUpdate100-4    	     100	  10644594 ns/op	23758243 B/op	   10608 allocs/op
BenchmarkUpdate1000-4   	       1	12064988411 ns/op	22628726584 B/op	 1006038 allocs/op
```
New:
```
BenchmarkUpdate1-4               5000000               302 ns/op             168 B/op          6 allocs/op
BenchmarkUpdate10-4               200000              9607 ns/op           17752 B/op         79 allocs/op
BenchmarkUpdate100-4                2000            745441 ns/op         1698392 B/op        714 allocs/op
BenchmarkUpdate1000-4                 20          68877041 ns/op        157273052 B/op      6791 allocs/op
```