### PR TITLE
Expose more cell fields (userEnteredValue, effectiveValue)

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -4,10 +4,12 @@ import "fmt"
 
 // Cell describes a cell data
 type Cell struct {
-	Row    uint
-	Column uint
-	Value  string
-	Note   string
+	Row            uint
+	Column         uint
+	Value          string
+	Note           string
+	rawValue       ExtendedValue
+	effectiveValue ExtendedValue
 
 	modifiedFields string
 }
@@ -15,4 +17,16 @@ type Cell struct {
 // Pos returns the cell's position like "A1"
 func (cell *Cell) Pos() string {
 	return numberToLetter(int(cell.Column)+1) + fmt.Sprintf("%d", cell.Row+1)
+}
+
+// RawValue returns the raw value of a cell as entered by a user.
+// Cells with formulas, for example, return the formula rather than the value of that formula.
+func (cell *Cell) RawValue() ExtendedValue {
+	return cell.rawValue
+}
+
+// EffectiveValue is the effective value of a cell.
+// Cells with formulas will return the value of that formula.
+func (cell *Cell) EffectiveValue() ExtendedValue {
+	return cell.effectiveValue
 }

--- a/service.go
+++ b/service.go
@@ -113,7 +113,7 @@ func (s *Service) FetchSpreadsheet(id string, options ...FetchSpreadsheetOption)
 		return config.cachedSpreadsheet, nil
 	}
 
-	fields := "spreadsheetId,properties.title,sheets(properties,data.rowData.values(formattedValue,note))"
+	fields := "spreadsheetId,properties.title,sheets(properties,data.rowData.values(userEnteredValue,effectiveValue,formattedValue,note))"
 	fields = url.QueryEscape(fields)
 	path := fmt.Sprintf("/spreadsheets/%s?fields=%s", id, fields)
 	body, err := s.get(path)

--- a/sheet.go
+++ b/sheet.go
@@ -47,10 +47,12 @@ func (sheet *Sheet) UnmarshalJSON(data []byte) error {
 					maxColumn = int(c)
 				}
 				cell := Cell{
-					Row:    r,
-					Column: c,
-					Value:  cellData.FormattedValue,
-					Note:   cellData.Note,
+					Row:            r,
+					Column:         c,
+					Value:          cellData.FormattedValue,
+					Note:           cellData.Note,
+					rawValue:       cellData.UserEnteredValue,
+					effectiveValue: cellData.EffectiveValue,
 				}
 				cells = append(cells, cell)
 			}


### PR DESCRIPTION
https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells
Exposing these two fields makes working with numbers a little nicer and working with formulas possible.
Closes #47 

side note: the Cell struct should just be removed and CellData could have helper methods added to make it nice to interact with like Cell, but maybe this is an issue for an actual issue