### PR TITLE
fix(bug): Fixes bug when infinite and NaN floats are mistakenly treated as numberValues

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -24,7 +24,7 @@ func cellValueType(val string) string {
 	if _, err := strconv.Atoi(val); err == nil {
 		return "numberValue"
 	}
-	if f, err := strconv.ParseFloat(val, 64); err == nil && isNumericFloat(f) {
+	if floatVal, err := strconv.ParseFloat(val, 64); err == nil && isNumericFloat(floatVal) {
 		return "numberValue"
 	}
 	if val == "TRUE" || val == "FALSE" {

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package spreadsheet
 
 import (
+	"math"
 	"strconv"
 )
 
@@ -23,7 +24,7 @@ func cellValueType(val string) string {
 	if _, err := strconv.Atoi(val); err == nil {
 		return "numberValue"
 	}
-	if _, err := strconv.ParseFloat(val, 64); err == nil {
+	if f, err := strconv.ParseFloat(val, 64); err == nil && isNumericFloat(f) {
 		return "numberValue"
 	}
 	if val == "TRUE" || val == "FALSE" {
@@ -31,4 +32,12 @@ func cellValueType(val string) string {
 	}
 
 	return "stringValue"
+}
+
+func isNumericFloat(val float64) bool {
+	if math.IsInf(val, 1) || math.IsInf(val, -1) || math.IsNaN(val) {
+		return false
+	}
+
+	return true
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,6 +25,11 @@ func TestCellValueType(t *testing.T) {
 	assert.Equal("numberValue", cellValueType("-2.23333"))
 	assert.Equal("boolValue", cellValueType("TRUE"))
 	assert.Equal("stringValue", cellValueType("test"))
+	assert.Equal("stringValue", cellValueType("inf"))
+	assert.Equal("stringValue", cellValueType("Infinity"))
+	assert.Equal("stringValue", cellValueType("-inf"))
+	assert.Equal("stringValue", cellValueType("-Infinity"))
+	assert.Equal("stringValue", cellValueType("NaN"))
 }
 
 func BenchmarkNumberToLetter(b *testing.B) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package spreadsheet
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,15 @@ func TestCellValueType(t *testing.T) {
 	assert.Equal("stringValue", cellValueType("-inf"))
 	assert.Equal("stringValue", cellValueType("-Infinity"))
 	assert.Equal("stringValue", cellValueType("NaN"))
+}
+
+func TestIsNumericFloat(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(isNumericFloat(-2.23333))
+	assert.True(isNumericFloat(0.01234))
+	assert.False(isNumericFloat(math.Inf(1)))
+	assert.False(isNumericFloat(math.Inf(-1)))
+	assert.False(isNumericFloat(math.NaN()))
 }
 
 func BenchmarkNumberToLetter(b *testing.B) {


### PR DESCRIPTION
This PR proposes to fix an edge-case when the contents that would be written into the cells match any of the special cases when parsing a float value and would categorised as `numberValue`:

"Inf", "+Inf", "-Inf", "Infinity", "+Infinity", "-Infinity" and "NaN" (all case-insensitive)

And would run into an exception by Google Sheets API:

```error status: INVALID_ARGUMENT, code:400, message: Invalid value at 'requests[27311].update_cells.rows[0].values[0].user_entered_value.number_value' (TYPE_DOUBLE), "Inf"```